### PR TITLE
BCF-5529: Set TMPDIR for the Backup Manager installer

### DIFF
--- a/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
+++ b/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
@@ -199,7 +199,7 @@ function cove_install_bm() {
             local link_name="${COVE_INSTALL_DIR}"
             cove_create_symlink "${target}" "${link_name}" || return $?
         else
-            cove_dirs=(bin etc lib sbin share temp var/log var/storage)
+            cove_dirs=(bin etc lib sbin share var/log var/storage)
             for cove_dir in "${cove_dirs[@]}"; do
                 local target="${target_install_dir}/${cove_dir}"
                 local link_name="${COVE_INSTALL_DIR}/${cove_dir}"
@@ -210,7 +210,7 @@ function cove_install_bm() {
 
     UserOutput ""
     UserOutput "Installing Backup Manager..."
-    "${COVE_INSTALLER_PATH}" --target "${COVE_TMPDIR}/mxb" 1>&7 2>&8 || return $?
+    TMPDIR="$COVE_TMPDIR" "${COVE_INSTALLER_PATH}" --target "${COVE_TMPDIR}/mxb" 1>&7 2>&8 || return $?
 
     # Extract the ReaR tarball because the installer does not do it in the rescue environment
     mkdir -p "${target_install_dir}/rear"


### PR DESCRIPTION
Jira-Ref: BCF-5529: [Linux BMR] The machine can not be restored due to "Not enough space left in /var/temp ..." error during the restore process


