### PR TITLE
BCF-5440: Linux System State fails on Linux SUSE 12.5

### DIFF
--- a/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
@@ -56,7 +56,11 @@ if test $dracut_binary ; then
     # nevertheless we set PATH to be on the safe side in general.
     # The --force option is needed because plain 'dracut' (at least in SLES15-SP5) fails with a message like
     # "dracut: Will not override existing initramfs (/boot/initrd-5.14.21-150500.55.28-default) without --force"
-    if chroot $TARGET_FS_ROOT /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $dracut_binary --force" ; then
+    dracut_args=""
+    if [ "$BACKUP" = "COVE" ] && [ -n "$COVE_KERNEL_VERSION" ]; then
+        dracut_args+="--kver $COVE_KERNEL_VERSION "
+    fi
+    if chroot $TARGET_FS_ROOT /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $dracut_binary --force $dracut_args" ; then
         LogPrint "Recreated initrd with $dracut_binary"
     else
         LogPrintError "Warning:

--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
@@ -220,10 +220,10 @@ function create_fs () {
             fi
             ;;
         (btrfs)
-            # Staring with btrfs-progs v5.15, the free space tree (space_cache=v2)
+            # Starting with btrfs-progs v5.15, the free space tree (space_cache=v2)
             # is the default for all newly created filesystems. Since Cove Rescue Media
             # uses btrfs-progs v6.2, it needs to disable the free space tree
-            # in case it wan't enabled on the source system.
+            # in case it wasn't enabled on the source system.
             btrfs_opts=""
             if [ "$BACKUP" = "COVE" ] && [[ ! "$options" == *"space_cache=v2"* ]]; then
                 btrfs_opts+="-R ^free-space-tree "

--- a/usr/share/rear/rescue/systemstate/COVE/default/600_store_cove_vars.sh
+++ b/usr/share/rear/rescue/systemstate/COVE/default/600_store_cove_vars.sh
@@ -9,4 +9,5 @@ cat <<EOF >>"$ROOTFS_DIR/etc/rear/rescue.conf"
 # from rescue/COVE/default/600_store_cove_vars.sh
 COVE_REAL_INSTALL_DIR="$(readlink -f "${COVE_INSTALL_DIR}")"
 COVE_TIMESTAMP="${COVE_TIMESTAMP}"
+COVE_KERNEL_VERSION="${KERNEL_VERSION}"
 EOF


### PR DESCRIPTION
Disable the free space tree in case it wasn't enabled on the source system.

