### PR TITLE
BCF-5657: Support RHEL and CentOS 6 restore

### DIFF
--- a/usr/share/rear/finalize/COVE/RedHatEnterpriseServer/050_create_selinux_dir.sh
+++ b/usr/share/rear/finalize/COVE/RedHatEnterpriseServer/050_create_selinux_dir.sh
@@ -2,6 +2,6 @@
 # Create /selinux directory on RHEL and CentOS 6
 #
 
-if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
+if [ "${OS_VERSION%%.*}" = "6" ] ; then
     mkdir -p "$TARGET_FS_ROOT/selinux" || true
 fi

--- a/usr/share/rear/finalize/COVE/default/050_create_selinux_dir.sh
+++ b/usr/share/rear/finalize/COVE/default/050_create_selinux_dir.sh
@@ -1,5 +1,5 @@
 #
-# Create /selinux directory on RHEL 6
+# Create /selinux directory on RHEL and CentOS 6
 #
 
 if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then

--- a/usr/share/rear/finalize/COVE/default/050_create_selinux_dir.sh
+++ b/usr/share/rear/finalize/COVE/default/050_create_selinux_dir.sh
@@ -1,0 +1,7 @@
+#
+# Create /selinux directory on RHEL 6
+#
+
+if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
+    mkdir -p "$TARGET_FS_ROOT/selinux" || true
+fi

--- a/usr/share/rear/finalize/Fedora/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/550_rebuild_initramfs.sh
@@ -59,8 +59,13 @@ NEW_INITRD_MODULES=( $( tr " " "\n" <<< "${NEW_INITRD_MODULES[*]}" | sort | uniq
 INITRD_MODULES="${OLD_INITRD_MODULES[*]} ${NEW_INITRD_MODULES[*]}"
 Log "New INITRD_MODULES='$INITRD_MODULES'"
 
-# Do not quote $INITRD_MODULES otherwise printf could not split words as separated arguments on separated lines:
-WITH_INITRD_MODULES=$( printf '%s\n' $INITRD_MODULES | awk '{printf "--add-drivers=%s ", $1}' )
+if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
+    # On RHEL and CentOS 6, dracut uses '--add-drivers SPACE-SEPARATED-LIST' syntax.
+    WITH_INITRD_MODULES="--add-drivers $INITRD_MODULES"
+else
+    # Do not quote $INITRD_MODULES otherwise printf could not split words as separated arguments on separated lines:
+    WITH_INITRD_MODULES=$( printf '%s\n' $INITRD_MODULES | awk '{printf "--add-drivers=%s ", $1}' )
+fi
 
 # Recreate any initrd or initramfs image under $TARGET_FS_ROOT/boot/ with new drivers
 # Images ignored:

--- a/usr/share/rear/finalize/Fedora/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/550_rebuild_initramfs.sh
@@ -59,7 +59,7 @@ NEW_INITRD_MODULES=( $( tr " " "\n" <<< "${NEW_INITRD_MODULES[*]}" | sort | uniq
 INITRD_MODULES="${OLD_INITRD_MODULES[*]} ${NEW_INITRD_MODULES[*]}"
 Log "New INITRD_MODULES='$INITRD_MODULES'"
 
-if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
+if [ "$OS_VENDOR" = "RedHatEnterpriseServer" ] && [ "${OS_VERSION%%.*}" = "6" ] ; then
     # On RHEL and CentOS 6, dracut uses '--add-drivers SPACE-SEPARATED-LIST' syntax.
     WITH_INITRD_MODULES="--add-drivers $INITRD_MODULES"
 else

--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
@@ -101,7 +101,7 @@ function create_fs () {
             fi
 
             ext_opts=""
-            if [ "$BACKUP" = "COVE" ] && [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
+            if [ "$BACKUP" = "COVE" ] && [ "$OS_VENDOR" = "RedHatEnterpriseServer" ] && [ "${OS_VERSION%%.*}" = "6" ] ; then
                 if [ "$fstype" = "ext4" ]; then
                     ext_opts="-O ^64bit,^metadata_csum,uninit_bg"
                 fi

--- a/usr/share/rear/verify/COVE/RedHatEnterpriseServer/350_check_vsyscall.sh
+++ b/usr/share/rear/verify/COVE/RedHatEnterpriseServer/350_check_vsyscall.sh
@@ -1,0 +1,8 @@
+#
+# Check if vsyscall=emulate is enabled on RHEL and CentOS 6
+#
+
+if [ "${OS_VERSION%%.*}" = "6" ] && ! grep -qw "vsyscall=emulate" /proc/cmdline; then
+    Error "RHEL and CentOS 6 systems require enabling vsyscall=emulate in the kernel boot parameters." \
+          "Please reboot the rescue system, press 'e' in the GRUB menu, and append 'vsyscall=emulate' to the boot parameters."
+fi

--- a/usr/share/rear/verify/COVE/default/390_check_cove.sh
+++ b/usr/share/rear/verify/COVE/default/390_check_cove.sh
@@ -18,7 +18,7 @@ fi
 
 if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
     if ! grep -qw "vsyscall=emulate" /proc/cmdline; then
-        Error "RHEL 6 requires enabling vsyscall=emulate in the kernel boot parameters." \
-              "Please reboot the rescue system, press 'e' in GRUB menu, and append 'vsyscall=emulate' in the boot parameters."
+        Error "RHEL and CentOS 6 systems requires enabling vsyscall=emulate in the kernel boot parameters." \
+              "Please reboot the rescue system, press 'e' in the GRUB menu, and append 'vsyscall=emulate' to the boot parameters."
     fi
 fi

--- a/usr/share/rear/verify/COVE/default/390_check_cove.sh
+++ b/usr/share/rear/verify/COVE/default/390_check_cove.sh
@@ -13,5 +13,12 @@ for executable in BackupFP ClientTool ProcessController; do
 done
 
 if [[ "${REAR_DIR_PREFIX}/" == "${COVE_INSTALL_DIR}/"* ]]; then
-    Error "Rear can not be executed from COVE_INSTALL_DIR"
+    Error "ReaR can not be executed from COVE_INSTALL_DIR"
+fi
+
+if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
+    if ! grep -qw "vsyscall=emulate" /proc/cmdline; then
+        Error "RHEL 6 requires enabling vsyscall=emulate in the kernel boot parameters." \
+              "Please reboot the rescue system, press 'e' in GRUB menu, and append 'vsyscall=emulate' in the boot parameters."
+    fi
 fi

--- a/usr/share/rear/verify/COVE/default/390_check_cove.sh
+++ b/usr/share/rear/verify/COVE/default/390_check_cove.sh
@@ -15,10 +15,3 @@ done
 if [[ "${REAR_DIR_PREFIX}/" == "${COVE_INSTALL_DIR}/"* ]]; then
     Error "ReaR can not be executed from COVE_INSTALL_DIR"
 fi
-
-if [[ "$OS_VENDOR" =~ "RedHat" ]] && [ "${OS_VERSION%%.*}" = "6" ] ; then
-    if ! grep -qw "vsyscall=emulate" /proc/cmdline; then
-        Error "RHEL and CentOS 6 systems requires enabling vsyscall=emulate in the kernel boot parameters." \
-              "Please reboot the rescue system, press 'e' in the GRUB menu, and append 'vsyscall=emulate' to the boot parameters."
-    fi
-fi


### PR DESCRIPTION
- Disable `64bit` and `metadata_csum` ext4 filesystem features on RHEL and CentOS 6. These features are not supported by GRUB and are likely unsupported by some other software on the systems.
- Fix dracut syntax for RHEL and CentOS 6