### PR TITLE
BCF-5670: [ReaR] RHEL-based systems with XFS are not bootable if recovered in non-debug mode

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3335,18 +3335,12 @@ VEEAM_BACKUPID="${VEEAM_BACKUPID:-}"
 ##
 # ReaR support for Cove Data Protection (Cove).
 
-REQUIRED_PROGS_COVE=( chgrp base64 /bin/kill )
-
-# Let the Backup Manager know that it is installing or running inside the rescue environment.
-KERNEL_CMDLINE_COVE="cove_rescue_media"
-
 # Cove install directory.
 # The default value is configured in site.conf during the Backup Manager installation.
 COVE_INSTALL_DIR=
 
 # The timestamp used to find the closest Files and folders backup session.
-# The timestamp value is passed by the Backup Manager via an environment variable, but it can be
-# overridden in local.conf or by the `cove_timestamp` boot parameter.
+# The timestamp value is passed by the Backup Manager via an environment variable.
 COVE_TIMESTAMP="${COVE_TIMESTAMP:-}"
 
 ##

--- a/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
+++ b/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
@@ -48,7 +48,7 @@ while read source target junk ; do
 
             if [ -e "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" ]; then
                 Log "Migrating XFS configuration $base_src_layout_partition.xfs to $base_dst_layout_partition.xfs"
-                cp "$v" "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" \
+                cp $v "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" \
                  "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_dst_layout_partition.xfs"
 
                 # Replace old device name in meta-data= option in XFS

--- a/usr/share/rear/layout/save/COVE/default/400_exclude_rear_config_dir.sh
+++ b/usr/share/rear/layout/save/COVE/default/400_exclude_rear_config_dir.sh
@@ -1,0 +1,6 @@
+# 400_exclude_rear_config_dir.sh
+#
+# Exclude ReaR config directory from CHECK_CONFIG_FILES array since this is not
+# recovered by the Backup Manager.
+
+CHECK_CONFIG_FILES=( $( RmInArray "$CONFIG_DIR" "${CHECK_CONFIG_FILES[@]}" ) )

--- a/usr/share/rear/prep/systemstate/COVE/default/400_prep_cove.sh
+++ b/usr/share/rear/prep/systemstate/COVE/default/400_prep_cove.sh
@@ -1,7 +1,0 @@
-#
-# Prepare stuff for Cove
-#
-
-REQUIRED_PROGS+=( "${REQUIRED_PROGS_COVE[@]}" )
-
-KERNEL_CMDLINE+=" ${KERNEL_CMDLINE_COVE} "


### PR DESCRIPTION
- Fix copying XFS configs when `rear recover` is run without debug mode
- Do not check config files after restore