### PR TITLE
BCF-5849: Support Bare Metal Recovery in Azure

### DIFF
--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -110,6 +110,9 @@ for current_device_path in /sys/block/* ; do
     test "$( < $current_device_path/removable )" = "1" && continue
     # Continue with next block device if the current one is designated as write-protected:
     is_write_protected $current_device_path && continue
+    # Continue with next block device if the current one is the COVE_RESCUE disk
+    device_name="$( get_device_name $current_device_path )"
+    is_cove_rescue_device "$device_name" && continue
     # Continue with next block device if no size can be read for the current one:
     test -r $current_device_path/size || continue
     current_size=$( get_disk_size $current_disk_name )
@@ -151,7 +154,11 @@ if ! is_true "$MIGRATION_MODE" ; then
         if test -e "/sys/block/$dev" ; then
             Log "Device /sys/block/$dev exists"
             newsize=$( get_disk_size $dev )
-            if test "$newsize" -eq "$size" ; then
+            device_name="$( get_device_name /"sys/block/$dev" )"
+            if is_cove_rescue_device "$device_name" ; then
+                LogPrint "Device $dev is the COVE_RESCUE disk (needs manual configuration)"
+                MIGRATION_MODE='true'
+            elif test "$newsize" -eq "$size" ; then
                 if is_write_protected "/sys/block/$dev"; then
                     LogPrint "Device $dev is designated as write-protected (needs manual configuration)"
                     MIGRATION_MODE='true'

--- a/usr/share/rear/lib/cove-functions.sh
+++ b/usr/share/rear/lib/cove-functions.sh
@@ -88,3 +88,12 @@ function cove_error_if_container() {
 
     Error "The system is detected as ${container} container. System state is not supported for containers."
 }
+
+function is_cove_rescue_device() {
+    local device_name="$1"
+
+    local label
+    label=$(blkid_label_of_device "$device_name")
+
+    [ "$label" = "COVE_RESCUE" ]
+}


### PR DESCRIPTION
Since Cove Rescue Media is VHD disk in Azure env, it is considered a
hard disk by ReaR and, as a result, might be used as a possible target
for disks mapping. To avoid this, we are excluding the rescue system
by the COVE_RESCUE label.