### PR TITLE
BCF-5793: Support BM vanilla branding for Linux BMR

### DIFF
--- a/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
+++ b/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
@@ -171,6 +171,9 @@ restore_args=(
     -exclude "${COVE_REAL_INSTALL_DIR}"
     -session-search-policy OldestIfRequestedNotFound
 )
+
+[ -e "${COVE_AUTH_TOOL_DIR}" ] && restore_args+=( -exclude "${COVE_AUTH_TOOL_DIR}" )
+
 [ -z "${COVE_TIMESTAMP}" ] || restore_args+=( -time "${COVE_TIMESTAMP}" )
 
 prompt="Select what to do"


### PR DESCRIPTION
During development we found one defect: mtls credentials can be overwritten. So, we decided to exclude mtls directory with credentials from the restore 