### PR TITLE
BCF-6329: feat(bm): Move WARN messages from standard output to error stream

### DIFF
--- a/tests/COVE/003_determine_efi_bootloader.bats
+++ b/tests/COVE/003_determine_efi_bootloader.bats
@@ -13,7 +13,7 @@ function setup() {
     # shellcheck disable=SC1091
     source "$REAR_SHARE_DIR/lib/global-functions.sh"
 
-    function LogPrint() {
+    function WarnPrint() {
         echo "$@"
     }
 }

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -398,6 +398,11 @@ function UserOutput () {
     { echo "$*" 1>&7 || true ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
 }
 
+# For cove warn messages
+function PrintWarn() {
+    { echo "$*" 1>&8 || true ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+}
+
 # For actually intended user error messages output to the original STDERR
 # regardless whether or not the user launched 'rear' in verbose mode:
 function PrintError () {
@@ -507,6 +512,13 @@ function DebugPrint () {
 function LogPrint () {
     { Log "$@"
       Print "$@"
+    } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+}
+
+# For cove warning messages
+function WarnPrint() {
+    { Log "$@"
+      PrintWarn "$@"
     } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
 }
 

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -220,25 +220,25 @@ declare -F efi_check_bootloader_path >/dev/null || function efi_check_bootloader
 declare -F efi_get_current_full_bootloader_path >/dev/null || function efi_get_current_full_bootloader_path {
     local current_boot
     if ! current_boot=$(efi_get_current_boot); then
-        LogPrint "WARN: EFI: Failed to get current boot"
+        WarnPrint "WARN: EFI: Failed to get current boot"
         return 1
     fi
 
     local partuuid
     if ! partuuid=$(efi_get_boot_partuuid "$current_boot"); then
-        LogPrint "WARN: EFI: Failed to get partuuid for the current boot '$current_boot'"
+        WarnPrint "WARN: EFI: Failed to get partuuid for the current boot '$current_boot'"
         return 1
     fi
 
     local mnt
     if ! mnt=$(efi_get_mountpoint "$partuuid"); then
-        LogPrint "WARN: EFI: Failed to get mountpoint for partuuid '$partuuid'"
+        WarnPrint "WARN: EFI: Failed to get mountpoint for partuuid '$partuuid'"
         return 1
     fi
 
     local path
     if ! path=$(efi_get_bootloader_path "$current_boot"); then
-        LogPrint "WARN: EFI: Failed to get bootloader path for the current boot '$current_boot'"
+        WarnPrint "WARN: EFI: Failed to get bootloader path for the current boot '$current_boot'"
         return 1
     fi
 
@@ -249,7 +249,7 @@ declare -F efi_get_current_full_bootloader_path >/dev/null || function efi_get_c
     local full_path="$mnt$path"
 
     if ! efi_check_bootloader_path "$full_path"; then
-        LogPrint "WARN: EFI: Bootloader path '$full_path' does not exist"
+        WarnPrint "WARN: EFI: Bootloader path '$full_path' does not exist"
         return 1
     fi
 


### PR DESCRIPTION
Jira-Ref: BCF-6329: Add mechanism to send rear warnings to sentry at backup time