### PR TITLE
BCF-6454: Linux system state backup error "Unknown bootloader (GRUB2-BLS)"

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -457,7 +457,23 @@ CDROM_SIZE=20
 # (cf. https://github.com/rear/rear/issues/1134) but the checklayout workflow
 # does not automatically recreate the rescue/recovery system.
 # Files matching FILES_TO_PATCH_PATTERNS are added to this list automatically.
-CHECK_CONFIG_FILES=( '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/multipath.conf' '/etc/udev/udev.conf' "$CONFIG_DIR" )
+CHECK_CONFIG_FILES=(
+'/etc/drbd/'
+'/etc/drbd.conf'
+'/etc/lvm/lvm.conf'
+'/etc/multipath.conf'
+'/etc/udev/udev.conf'
+"$CONFIG_DIR"
+# Bootloaders that use BLS (Boot Loader Specification) instead of a config file
+# such as grub.cfg read boot entries from /boot/loader/entries
+# or /boot/efi/loader/entries and populate the boot menu based on these entries.
+#
+# Bootloader files are usually added in layout/save/default/450_check_bootloader_files.sh,
+# but BLS files are common to all bootloaders that support BLS, so we add them here instead.
+/[b]oot/efi/loader/entries/*.conf
+/[b]oot/efi/loader/loader.conf
+/[b]oot/loader/entries/*.conf
+)
 #
 # FILES_TO_PATCH_PATTERNS is a space-separated list of shell glob patterns.
 # Files that match are eligible for a final migration of UUIDs and other

--- a/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
@@ -39,6 +39,37 @@ fi
 my_udevtrigger
 sleep 5
 
+# Run 'sdbootutil mkinitrd' to regenerate the initrd on systems that use
+# GRUB2 with BLS. sdbootutil runs dracut under the hood and creates new
+# bootloader entries, along with new initrds used by these entries.
+local sysconfig_bootloader
+if sysconfig_bootloader="$(get_sysconfig_bootloader)" \
+    && [ "$sysconfig_bootloader" = "grub2-bls" ] ; then
+    local sdbootutil_binary
+    sdbootutil_binary=$( chroot "$TARGET_FS_ROOT" /bin/bash -c 'PATH=/sbin:/usr/sbin:/usr/bin:/bin type -P sdbootutil' )
+    if test "$sdbootutil_binary" ; then
+        if chroot "$TARGET_FS_ROOT" /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $sdbootutil_binary mkinitrd" ; then
+            LogPrint "Recreated initrd and boot entry with $sdbootutil_binary"
+        else
+            LogPrintError "Warning:
+Failed to recreate initrd and boot entry with $sdbootutil_binary.
+Check '$RUNTIME_LOGFILE' why $sdbootutil_binary failed
+and decide if the recreated system will boot
+with the initrd 'as is' from the backup restore.
+"
+        fi
+    else
+    LogPrintError "Warning:
+Cannot recreate initrd bootloader entry (sdbootutil not found in the recreated system).
+Check the recreated system (mounted at $TARGET_FS_ROOT)
+and decide if the recreated system will boot
+with the initrd 'as is' from the backup restore.
+"
+    fi
+
+    return 0
+fi
+
 # Run dracut directly in chroot without a login shell in between (see https://github.com/rear/rear/issues/862).
 # We need the dracut binary in the chroot environment i.e. the dracut binary in the recreated system.
 # Normally we would use a login shell like: chroot $TARGET_FS_ROOT /bin/bash --login -c 'type -P dracut'

--- a/usr/share/rear/layout/save/default/445_guess_bootloader.sh
+++ b/usr/share/rear/layout/save/default/445_guess_bootloader.sh
@@ -27,15 +27,20 @@ if test "$BOOTLOADER" ; then
 fi
 
 # When a bootloader is specified in /etc/sysconfig/bootloader use that:
-if test -f /etc/sysconfig/bootloader ; then
-    # SUSE uses LOADER_TYPE, and others?
-    # Getting values from sysconfig files is like sourcing shell scripts so that the last setting wins:
-    sysconfig_bootloader=$( grep ^LOADER_TYPE /etc/sysconfig/bootloader | cut -d= -f2 | tail -n1 | sed -e 's/"//g' )
-    if test "$sysconfig_bootloader" ; then
-        LogPrint "Using sysconfig bootloader '$sysconfig_bootloader' for 'rear recover'"
-        echo "$sysconfig_bootloader" | tr '[a-z]' '[A-Z]' >$bootloader_file
-        return
-    fi
+#
+# On SUSE, the possible values for BOOTLOADER_TYPE are:
+# grub,grub2,grub2-efi,grub2-bls,systemd-boot,none
+#
+# Proceed to auto-detect the bootloader in the steps below if /etc/sysconfig/bootloader
+# contains 'none', 'grub2-bls' (which should be treated as GRUB2 or GRUB2-EFI),
+# or 'grub2-efi' (which can be used on hybrid systems and leads to losing
+# the capability to boot in a BIOS environment, making them purely EFI after recovery
+# see https://github.com/rear/rear/pull/3128#issuecomment-2176373583)
+if sysconfig_bootloader="$(get_sysconfig_bootloader)" \
+    && [[ ! "$sysconfig_bootloader" =~ ^(grub2-efi|grub2-bls|none)$ ]] ; then
+    LogPrint "Using sysconfig bootloader '$sysconfig_bootloader' for 'rear recover'"
+    echo "$sysconfig_bootloader" | tr '[a-z]' '[A-Z]' >$bootloader_file
+    return
 fi
 
 # On ARM, guess the dummy bootloader:

--- a/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
+++ b/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
@@ -12,6 +12,9 @@ used_bootloader=( $( cat $VAR_DIR/recovery/bootloader ) )
 # that with 'shopt -s nullglob' files that do not exist will not appear
 # so nonexistent files are not appended to CHECK_CONFIG_FILES
 # cf. https://github.com/rear/rear/pull/2796#issuecomment-1117171070
+#
+# Since BLS (Boot Loader Specification) files are common to bootloaders,
+# they are added to CHECK_CONFIG_FILES in default.conf.
 case $used_bootloader in
     (EFI|GRUB2-EFI)
         CHECK_CONFIG_FILES+=( /boot/efi/EFI/*/grub*.cfg )

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -995,4 +995,27 @@ function make_pxelinux_config_grub {
     echo "}"
 }
 
+function get_sysconfig_bootloader() {
+    local sysconfig_bootloader_path=/etc/sysconfig/bootloader
+    if test "$RECOVERY_MODE" ; then
+        sysconfig_bootloader_path="$TARGET_FS_ROOT$sysconfig_bootloader_path"
+    fi
+
+    if ! test -f "$sysconfig_bootloader_path" ; then
+        return 1
+    fi
+
+    local sysconfig_bootloader
+
+    # SUSE uses LOADER_TYPE, and others?
+    # Getting values from sysconfig files is like sourcing shell scripts so that the last setting wins:
+    sysconfig_bootloader=$( grep ^LOADER_TYPE "$sysconfig_bootloader_path" | cut -d= -f2 | tail -n1 | sed -e 's/"//g' )
+
+    if ! test "$sysconfig_bootloader" ; then
+        return 1
+    fi
+
+    echo "$sysconfig_bootloader"
+}
+
 # vim: set et ts=4 sw=4


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): https://n-able.atlassian.net/browse/BCF-6454

* How was this pull request tested?
  Manually recovered openSUSE Tumbleweed, RHEL 10, Fedora 43 and Rocky 9.6 cloud image in Azure

* Description of the changes in this pull request:
  Add support for `GRUB2-BLS`. The recovery process is identical to `GRUB2-EFI`.
