### PR TITLE
BCF-6484: [ReaR] Specialise BugError for Cove

### DIFF
--- a/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
+++ b/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
@@ -41,6 +41,6 @@ case $used_bootloader in
         CHECK_CONFIG_FILES+=( /[e]tc/zipl.conf )
         ;;
     (*)
-        BugError "Unknown bootloader ($used_bootloader) - ask for sponsoring to get this fixed"
+        BugError "Unknown bootloader: $used_bootloader"
         ;;
 esac

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -847,8 +847,11 @@ function Error () {
 # for example when a ReaR function is called with wrong
 # or missing required parameters and things like that.
 function BugError () {
-    { local caller_source="$( CallerSource )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
-    Error "
+    if is_cove; then
+        Error "$@"
+    else
+        { local caller_source="$( CallerSource )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+        Error "
 ====================
 BUG in $caller_source:
 $*
@@ -857,6 +860,7 @@ Please report it at $BUG_REPORT_SITE
 and include all related parts from $RUNTIME_LOGFILE
 preferably the whole debug information via 'rear -D $WORKFLOW'
 ===================="
+    fi
 }
 
 # Error out with a deprecation info


### PR DESCRIPTION
##### Pull Request Details:

* Type: *Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): https://n-able.atlassian.net/browse/BCF-6484

* How was this pull request tested?
  Manually started the backup session on openSUSE Tumbleweed and checked that the error message is expected

* Description of the changes in this pull request:
  Call `Error` instead of `BugError` if Cove is used as a backup solution

