### PR TITLE
BCF-6482: Allow to exclude nodes for FF restore during BMR

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3373,6 +3373,9 @@ COVE_VERIFY_PATHS=(/boot/efi /usr/bin /usr/sbin /usr/lib)
 # configs - check the hash sum of configuration files specified in CHECK_CONFIG_FILES
 COVE_CHECK_INTEGRITY="${COVE_CHECK_INTEGRITY:-binaries}"
 
+# Node paths that will be excluded from FileSystem restore session
+COVE_EXCLUDE_NODES_FROM_RESTORE=()
+
 ##
 # End of BACKUP=COVE default settings.
 ####

--- a/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
+++ b/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
@@ -168,11 +168,16 @@ restore_args=(
     control.restore.start
     -datasource FileSystem
     -restore-to "${TARGET_FS_ROOT}"
-    -exclude "${COVE_REAL_INSTALL_DIR}"
     -session-search-policy OldestIfRequestedNotFound
 )
 
-[ -e "${COVE_AUTH_TOOL_DIR}" ] && restore_args+=( -exclude "${COVE_AUTH_TOOL_DIR}" )
+COVE_EXCLUDE_NODES_FROM_RESTORE+=( "${COVE_REAL_INSTALL_DIR}" )
+
+[ -e "${COVE_AUTH_TOOL_DIR}" ] && COVE_EXCLUDE_NODES_FROM_RESTORE+=( "${COVE_AUTH_TOOL_DIR}" )
+
+for exclusion in "${COVE_EXCLUDE_NODES_FROM_RESTORE[@]}"; do
+    restore_args+=( -exclude "$exclusion" )
+done
 
 [ -z "${COVE_TIMESTAMP}" ] || restore_args+=( -time "${COVE_TIMESTAMP}" )
 


### PR DESCRIPTION
Add the `COVE_EXCLUDE_NODES_FROM_RESTORE` variable to allow to exclude nodes for FF restore during BMR

