### PR TITLE
BCF-6388: [REAR] Remove the legacy part of code about AuthTool certificate storage location

### DIFF
--- a/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
+++ b/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
@@ -8,7 +8,6 @@ readonly GREEN='\033[0;32m'
 readonly NC='\033[0m' # No color
 
 readonly COVE_CLIENT_TOOL="${COVE_INSTALL_DIR}/bin/ClientTool"
-readonly COVE_AUTH_TOOL_DIR="/root/.auth-tool"
 
 SKIP_PROGRESS_BAR=0
 
@@ -120,15 +119,6 @@ function cove_move_dir_to_target() {
     ln -s "${TARGET_FS_ROOT}/${source_dir#/}" "${source_dir}"
 }
 
-# Moves Cove installation files and credentials to target file system
-function cove_move_files_to_target() {
-    # Move Backup manager installation files to target file system
-    cove_move_dir_to_target "${COVE_INSTALL_DIR}"
-
-    # Move mTLS credentials to target file system
-    cove_move_dir_to_target "${COVE_AUTH_TOOL_DIR}"
-}
-
 # Waits for a new FileSystem restore session and gets its status
 # $1: prev sessions
 function cove_wait_for_new_session() {
@@ -152,8 +142,8 @@ function cove_wait_for_new_session() {
 UserOutput "
 The System is now ready for restore."
 
-# Move Backup manager installation files and credentials to target file system
-cove_move_files_to_target
+# Move Backup manager installation files to target file system
+cove_move_dir_to_target "${COVE_INSTALL_DIR}"
 
 # Start Backup Manager
 cove_start_pc
@@ -172,8 +162,6 @@ restore_args=(
 )
 
 COVE_EXCLUDE_NODES_FROM_RESTORE+=( "${COVE_REAL_INSTALL_DIR}" )
-
-[ -e "${COVE_AUTH_TOOL_DIR}" ] && COVE_EXCLUDE_NODES_FROM_RESTORE+=( "${COVE_AUTH_TOOL_DIR}" )
 
 for exclusion in "${COVE_EXCLUDE_NODES_FROM_RESTORE[@]}"; do
     restore_args+=( -exclude "$exclusion" )


### PR DESCRIPTION
* after changes in the ticket BCF-6344 certificate
* directory for AuthTool on Linux will be located at /opt/MXB/var/storage/certificates
