### PR TITLE
BCF-6588: [Sentry] Send events to Sentry via ClientTool during Linux BMR

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3360,6 +3360,10 @@ COVE_INSTALL_DIR=
 # The timestamp value is passed by the Backup Manager via an environment variable.
 COVE_TIMESTAMP="${COVE_TIMESTAMP:-}"
 
+# The OS version of the system that is backed up.
+# The OS version value is passed by the Backup Manager via an environment variable.
+COVE_OS_VERSION="${COVE_OS_VERSION:-}"
+
 # Verify binaries hash sum after recovery
 # Set to 1 to enable verification, 0 to disable
 COVE_VERIFY_BINARIES=0

--- a/usr/share/rear/rescue/systemstate/COVE/default/600_store_cove_vars.sh
+++ b/usr/share/rear/rescue/systemstate/COVE/default/600_store_cove_vars.sh
@@ -6,8 +6,9 @@
 
 cat <<EOF >>"$ROOTFS_DIR/etc/rear/rescue.conf"
 
-# from rescue/COVE/default/600_store_cove_vars.sh
+# from rescue/systemstate/COVE/default/600_store_cove_vars.sh
 COVE_REAL_INSTALL_DIR="$(readlink -f "${COVE_INSTALL_DIR}")"
 COVE_TIMESTAMP="${COVE_TIMESTAMP}"
+COVE_OS_VERSION="${COVE_OS_VERSION}"
 COVE_KERNEL_VERSION="${KERNEL_VERSION}"
 EOF


### PR DESCRIPTION
accept COVE_OS_VERSION env variable and write it to rescue.conf during `mksystemstate`

* the COVE_OS_VERSION value can be used during Linux BMR to report the version of the recovered system to Sentry

BCF-[6588](https://n-able.atlassian.net/browse/BCF-6588): [Sentry] Send events to Sentry via ClientTool during Linux BMR
