### PR TITLE
BCF-6776: Some graphical mode settings missing in grub.cfg after BMR of BIOS system (Deb12, Deb10)

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
@@ -98,19 +98,12 @@ is_grub2_installed || return 0
 
 LogPrint "Installing GRUB2 boot loader..."
 
-# Check if we find GRUB2 where we expect it (GRUB2 can be in boot/grub or boot/grub2):
-grub_name="grub2"
-if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
-    grub_name="grub"
-    if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
-        LogPrintError "Cannot install GRUB2 (neither boot/grub nor boot/grub2 directory in $TARGET_FS_ROOT)"
-        return 1
-    fi
-fi
+# Check if we find GRUB2 where we expect it:
+grub_name="$( get_target_grub2_name )" || return 1
 
 # Generate GRUB configuration file anew to be on the safe side (this could be even mandatory in MIGRATION_MODE):
-if ! run_in_chroot "$grub_name-mkconfig -o /boot/$grub_name/grub.cfg" ; then
-    LogPrintError "Failed to generate boot/$grub_name/grub.cfg in $TARGET_FS_ROOT - trying to install GRUB2 nevertheless"
+if ! grub2_mkconfig ; then
+    LogPrint "Trying to install GRUB2 despite GRUB config generation failure"
 fi
 
 # When GRUB2_INSTALL_DEVICES is specified by the user

--- a/usr/share/rear/finalize/Linux-ppc64le/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/660_install_grub2.sh
@@ -74,22 +74,15 @@ type -p grub-probe || type -p grub2-probe || return 0
 
 LogPrint "Installing GRUB2 boot loader on PPC64/PPC64LE..."
 
-# Check if we find GRUB2 where we expect it (GRUB2 can be in boot/grub or boot/grub2):
-grub_name="grub2"
-if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
-    grub_name="grub"
-    if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
-        LogPrintError "Cannot install GRUB2 (neither boot/grub nor boot/grub2 directory in $TARGET_FS_ROOT)"
-        return 1
-    fi
-fi
+# Check if we find GRUB2 where we expect it:
+grub_name="$( get_target_grub2_name )" || return 1
 
 # Generate GRUB configuration file anew to be on the safe side (this could be even mandatory in MIGRATION_MODE):
 local grub2_config_generated="yes"
-if ! run_in_chroot "$grub_name-mkconfig -o /boot/$grub_name/grub.cfg" ; then
+if ! grub2_mkconfig ; then
     grub2_config_generated="no"
     # TODO: We should make this fatal.  Outdated/incomplete/just wrong grub2.cfg may result into an unbootable system.
-    LogPrintError "Failed to generate boot/$grub_name/grub.cfg in $TARGET_FS_ROOT - trying to install GRUB2 nevertheless"
+    LogPrint "Trying to install GRUB2 despite GRUB config generation failure"
 fi
 
 # Detect platform, e.g. PowerNV, in advance.

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -1062,4 +1062,32 @@ function is_grub2_used() {
     esac
 }
 
+function get_target_grub2_name() {
+    local grub_name
+    for grub_name in grub2 grub; do
+        if [ -d "$TARGET_FS_ROOT/boot/$grub_name" ]; then
+            echo "$grub_name"
+            return 0
+        fi
+    done
+
+    LogPrintError "Cannot find GRUB2 (neither boot/grub nor boot/grub2 directory exists in $TARGET_FS_ROOT)"
+    return 1
+}
+
+function grub2_mkconfig() {
+    local grub_name
+    grub_name="$( get_target_grub2_name )" || return 1
+
+    local lang_prefix=""
+    local target_lang
+    target_lang="$( get_lang )" && lang_prefix="LANG=$target_lang"
+
+    if ! run_in_chroot "$lang_prefix $grub_name-mkconfig -o /boot/$grub_name/grub.cfg" ; then
+        LogPrintError "Failed to generate boot/$grub_name/grub.cfg in $TARGET_FS_ROOT"
+        return 1
+    fi
+    return 0
+}
+
 # vim: set et ts=4 sw=4

--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -325,3 +325,33 @@ function run_in_chroot() {
 
     chroot "$TARGET_FS_ROOT" /bin/bash --login $noprofile -c "$command"
 }
+
+# Get LANG from known system locale config files.
+# In RECOVERY_MODE, reads from $TARGET_FS_ROOT; otherwise from the running system.
+# Outputs the LANG value on stdout. Returns 1 if not found.
+function get_lang () {
+    local locale_files=(
+        "/etc/locale.conf"     # RHEL-based
+        "/etc/sysconfig/i18n"  # RHEL <= 6
+        "/etc/default/locale"  # Debian-based
+    )
+
+    local locale_file
+    for locale_file in "${locale_files[@]}"; do
+        if test "$RECOVERY_MODE"; then
+            locale_file="$TARGET_FS_ROOT$locale_file"
+        fi
+
+        [ -f "$locale_file" ] || continue
+
+        local lang_value
+        lang_value=$( grep '^LANG=' "$locale_file" | tail -1 | cut -d= -f2 | tr -d "\"'" || true )
+
+        if [ -n "$lang_value" ]; then
+            echo "$lang_value"
+            return 0
+        fi
+    done
+
+    return 1
+}

--- a/usr/share/rear/restore/YUM/default/950_grub2_mkconfig.sh
+++ b/usr/share/rear/restore/YUM/default/950_grub2_mkconfig.sh
@@ -34,7 +34,7 @@ mount -o bind /dev $TARGET_FS_ROOT/dev || true
 # A login shell in between is needed when shell scripts are called inside 'chroot'
 # cf. https://github.com/rear/rear/issues/862#issuecomment-282039428
 # In particular grub2-mkconfig is a shell script that calls other shell scripts:
-run_in_chroot '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg'
+grub2_mkconfig
 
 # FIXME: This should not be needed here but work via finalize/Linux-i386/660_install_grub2.sh
 # Install bootloader in the target system:

--- a/usr/share/rear/restore/ZYPPER/default/950_grub2_mkconfig.sh
+++ b/usr/share/rear/restore/ZYPPER/default/950_grub2_mkconfig.sh
@@ -31,7 +31,7 @@ chroot $TARGET_FS_ROOT /sbin/mkinitrd -v
 # A login shell in between is needed when shell scripts are called inside 'chroot'
 # cf. https://github.com/rear/rear/issues/862#issuecomment-282039428
 # In particular grub2-mkconfig is a shell script that calls other shell scripts:
-run_in_chroot '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg'
+grub2_mkconfig
 
 # FIXME: This should not be needed here but work via finalize/Linux-i386/660_install_grub2.sh
 # Install bootloader in the target system:


### PR DESCRIPTION
* added a helper function to read the target system locale from one of the locale files in the target system
* applied the target system locale to the grub2-mkconfig calls

[BCF-6776](https://n-able.atlassian.net/browse/BCF-6776): Some graphical mode settings missing in grub.cfg after BMR of BIOS system (Deb12, Deb10)



[BCF-6776]: https://n-able.atlassian.net/browse/BCF-6776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ