### PR TITLE
BCF-7096: Activate swap partition for BMR needs

### DIFF
--- a/tests/COVE/003_determine_efi_bootloader.bats
+++ b/tests/COVE/003_determine_efi_bootloader.bats
@@ -14,7 +14,7 @@ function setup() {
     source "$REAR_SHARE_DIR/lib/global-functions.sh"
 
     function WarnPrint() {
-        echo "$@"
+        echo "WARN: $@"
     }
 }
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3380,6 +3380,10 @@ COVE_CHECK_INTEGRITY="${COVE_CHECK_INTEGRITY:-binaries}"
 # Node paths that will be excluded from FileSystem restore session
 COVE_EXCLUDE_NODES_FROM_RESTORE=()
 
+# Activate swap partition(s) before the FileSystem restore.
+# Set to 0 to disable.
+COVE_ACTIVATE_SWAP_PARTITIONS=1
+
 ##
 # End of BACKUP=COVE default settings.
 ####

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -517,8 +517,8 @@ function LogPrint () {
 
 # For cove warning messages
 function WarnPrint() {
-    { Log "$@"
-      PrintWarn "$@"
+    { Log "WARN:" "$@"
+      PrintWarn "WARN:" "$@"
     } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
 }
 

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -220,25 +220,25 @@ declare -F efi_check_bootloader_path >/dev/null || function efi_check_bootloader
 declare -F efi_get_current_full_bootloader_path >/dev/null || function efi_get_current_full_bootloader_path {
     local current_boot
     if ! current_boot=$(efi_get_current_boot); then
-        WarnPrint "WARN: EFI: Failed to get current boot"
+        WarnPrint "EFI: Failed to get current boot"
         return 1
     fi
 
     local partuuid
     if ! partuuid=$(efi_get_boot_partuuid "$current_boot"); then
-        WarnPrint "WARN: EFI: Failed to get partuuid for the current boot '$current_boot'"
+        WarnPrint "EFI: Failed to get partuuid for the current boot '$current_boot'"
         return 1
     fi
 
     local mnt
     if ! mnt=$(efi_get_mountpoint "$partuuid"); then
-        WarnPrint "WARN: EFI: Failed to get mountpoint for partuuid '$partuuid'"
+        WarnPrint "EFI: Failed to get mountpoint for partuuid '$partuuid'"
         return 1
     fi
 
     local path
     if ! path=$(efi_get_bootloader_path "$current_boot"); then
-        WarnPrint "WARN: EFI: Failed to get bootloader path for the current boot '$current_boot'"
+        WarnPrint "EFI: Failed to get bootloader path for the current boot '$current_boot'"
         return 1
     fi
 
@@ -249,7 +249,7 @@ declare -F efi_get_current_full_bootloader_path >/dev/null || function efi_get_c
     local full_path="$mnt$path"
 
     if ! efi_check_bootloader_path "$full_path"; then
-        WarnPrint "WARN: EFI: Bootloader path '$full_path' does not exist"
+        WarnPrint "EFI: Bootloader path '$full_path' does not exist"
         return 1
     fi
 

--- a/usr/share/rear/restore/COVE/default/300_activate_swap_partitions.sh
+++ b/usr/share/rear/restore/COVE/default/300_activate_swap_partitions.sh
@@ -1,0 +1,29 @@
+# Activate swap partition(s) (if they exist) to extend virtual memory before Backup Manager restore starts
+
+is_true "$COVE_ACTIVATE_SWAP_PARTITIONS" || return 0
+
+local device
+local swap_devices=()
+while read -r _ device _; do
+    swap_devices+=("$device")
+done < <( grep "^swap " "$LAYOUT_FILE" )
+
+if [ ${#swap_devices[@]} -eq 0 ]; then
+    LogPrint "No swap partitions found in $LAYOUT_FILE, skipping swap activation."
+    return 0
+fi
+
+# Deactivate any currently active swap. This is needed in case of BMR restart.
+if tail -n +2 /proc/swaps 2>/dev/null | grep -q .; then
+    LogPrint "Deactivating existing swap before reactivation."
+    swapoff -v -a || LogPrintError "Failed to deactivate existing swap. Continuing anyway."
+fi
+
+for device in "${swap_devices[@]}"; do
+    if [ -b "$device" ]; then
+        LogPrint "Activating swap on $device"
+        swapon "$device" || LogPrintError "Failed to activate swap on $device"
+    else
+        LogPrintError "Swap device $device not found or not a block device, skipping."
+    fi
+done

--- a/usr/share/rear/restore/COVE/default/300_activate_swap_partitions.sh
+++ b/usr/share/rear/restore/COVE/default/300_activate_swap_partitions.sh
@@ -22,8 +22,8 @@ fi
 for device in "${swap_devices[@]}"; do
     if [ -b "$device" ]; then
         LogPrint "Activating swap on $device"
-        swapon "$device" || LogPrintError "Failed to activate swap on $device"
+        swapon "$device" || WarnPrint "Failed to activate swap on $device"
     else
-        LogPrintError "Swap device $device not found or not a block device, skipping."
+        WarnPrint "Swap device $device not found or not a block device, skipping."
     fi
 done


### PR DESCRIPTION
* activate swap partition(s) before starting restore with Backup Manager

[BCF-7096](https://n-able.atlassian.net/browse/BCF-7096): Activate swap partition for BMR needs




[BCF-7096]: https://n-able.atlassian.net/browse/BCF-7096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ