### PR TITLE
BCF-7171: [Linux BMR ] Switch to jemalloc with disabled THP to reduce RSS usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                         shellHelper.exec('Upload', """
                             VERSION="\$(make version)"
                             PACKAGE="rear-\${VERSION}.tar.gz"
-                            TARGET_NAME="\$PACKAGE"
+                            TARGET_PACKAGE="\$PACKAGE"
                             if [ "${envType}" != "dev" ]; then
                                 COMMIT_REV="\$(git rev-parse HEAD | cut -c 1-8)"
                                 TARGET_PACKAGE="rear-\${VERSION}-\${COMMIT_REV}.tar.gz"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3380,6 +3380,13 @@ COVE_CHECK_INTEGRITY="${COVE_CHECK_INTEGRITY:-binaries}"
 # Node paths that will be excluded from FileSystem restore session
 COVE_EXCLUDE_NODES_FROM_RESTORE=()
 
+# Use jemalloc (an alternative memory allocator) to reduce RSS usage during
+# File system restore
+COVE_USE_JEMALLOC="${COVE_USE_JEMALLOC:-yes}"
+# jemalloc configuration
+# See https://github.com/jemalloc/jemalloc/blob/dev/TUNING.md for details
+COVE_MALLOC_CONF="background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:1000"
+
 ##
 # End of BACKUP=COVE default settings.
 ####

--- a/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
+++ b/usr/share/rear/restore/COVE/default/400_restore_with_cove.sh
@@ -91,9 +91,23 @@ function cove_stop_pc() {
 function cove_start_pc() {
     local pid
     pid="$(get_pc_pid)"
-    if [ -z "$pid" ]; then
-        "${COVE_INSTALL_DIR}/bin/ProcessController" serve
+    if [ -n "$pid" ]; then
+        return 0
     fi
+
+    (
+        if is_true "$COVE_USE_JEMALLOC"; then
+            local jemalloc_path=""
+            jemalloc_path="$(ldconfig -p | awk '/libjemalloc.so.2/{print $NF; exit}')"
+            if [ -n "$jemalloc_path" ] && [ -e "$jemalloc_path" ]; then
+                export LD_PRELOAD="$jemalloc_path"
+                export MALLOC_CONF="$COVE_MALLOC_CONF"
+            else
+                LogPrintError "COVE_USE_JEMALLOC is true, but jemalloc not found"
+            fi
+        fi
+        "${COVE_INSTALL_DIR}/bin/ProcessController" serve
+    )
 }
 
 # Gets FileSystem restore sessions


### PR DESCRIPTION
- Switch to `jemalloc` with disabled THP by default
- Fix invalid var name in Jenkinsfile


