### PR TITLE
BCF-7100: Respect device identifier type (dm-name-<dm_name> / dm-uuid-<dm_uuid>) during disk-by-id 

### DIFF
--- a/tests/COVE/004_udev_functions.bats
+++ b/tests/COVE/004_udev_functions.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+
+#
+# Unit tests for udev functions
+#
+
+function setup_file() {
+    REAR_SHARE_DIR="$(realpath "$BATS_TEST_DIRNAME/../../usr/share/rear")"
+    export REAR_SHARE_DIR
+}
+
+function setup() {
+    # shellcheck disable=SC1091
+    source "$REAR_SHARE_DIR/lib/udev-functions.sh"
+}
+
+@test "Check device identifier type match: both dm-name-<dm_name>" {
+    run check_device_identifier_type_match "dm-name-srcname" "dm-name-dstname"
+    [ $status -eq 0 ]
+}
+
+@test "Check device identifier type match: both dm-uuid-<dm_uuid>" {
+    run check_device_identifier_type_match "dm-uuid-srcuuid" "dm-uuid-dstuuid"
+    [ $status -eq 0 ]
+}
+
+@test "Check device identifier type match: src is dm-name-<dm_name> and dst is dm-uuid-<dm_uuid>" {
+    run check_device_identifier_type_match "dm-name-srcname" "dm-uuid-dstuuid"
+    [ $status -eq 1 ]
+}
+
+@test "Check device identifier type match: src is dm-uuid-<dm_uuid> and dst is dm-name-<dm_name>" {
+    run check_device_identifier_type_match "dm-uuid-srcuuid" "dm-name-dstname"
+    [ $status -eq 1 ]
+}
+
+@test "Check device identifier type match: both have unexpected types" {
+    run check_device_identifier_type_match "scsi-srcid" "ata-dstid"
+    [ $status -eq 0 ]
+}
+
+@test "Get dm-uuid-<dm_uuid> identifier though dm-name-<dm_name> is returned first" {
+    function UdevSymlinkName() {
+        echo -n "/dev/ubuntu-vg/ubuntu-lv "
+        echo -n "/dev/disk/by-dname/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/mapper/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-id/dm-name-ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-id/dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv "
+        echo -n "/dev/disk/by-uuid/9d830822-b26a-4188-a9e4-40f6c8e6697b"
+    }
+
+    run get_new_device_identifier \
+            "ubuntu--vg-ubuntu--lv" \
+            "dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv"
+
+    [ $status -eq 0 ]
+    [ "$output" = "dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv" ]
+}
+
+@test "Get dm-name-<dm_name> identifier though dm-uuid-<dm_uuid> is returned first" {
+    function UdevSymlinkName() {
+        echo -n "/dev/ubuntu-vg/ubuntu-lv "
+        echo -n "/dev/disk/by-dname/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/mapper/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-id/dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv "
+        echo -n "/dev/disk/by-id/dm-name-ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-uuid/9d830822-b26a-4188-a9e4-40f6c8e6697b"
+    }
+
+    run get_new_device_identifier \
+            "ubuntu--vg-ubuntu--lv" \
+            "dm-name-ubuntu--vg-ubuntu--lv"
+
+    [ $status -eq 0 ]
+    [ "$output" = "dm-name-ubuntu--vg-ubuntu--lv" ]
+}
+
+@test "Get first /dev/disk/by-id identifier for unexpected types" {
+    function UdevSymlinkName() {
+        echo -n "/dev/ubuntu-vg/ubuntu-lv "
+        echo -n "/dev/disk/by-dname/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/mapper/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-id/dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv "
+        echo -n "/dev/disk/by-id/dm-name-ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-uuid/9d830822-b26a-4188-a9e4-40f6c8e6697b"
+    }
+
+    run get_new_device_identifier \
+            "ubuntu--vg-ubuntu--lv" \
+            "dm-mytype-ubuntu--vg-ubuntu--lv"
+
+    [ $status -eq 0 ]
+    [ "$output" = "dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv" ]
+}
+
+@test "Get dm-name-<dm_name> when there is no dm-uuid-<dm_uuid>" {
+    function UdevSymlinkName() {
+        echo -n "/dev/ubuntu-vg/ubuntu-lv "
+        echo -n "/dev/disk/by-dname/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/mapper/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-id/dm-name-ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-uuid/9d830822-b26a-4188-a9e4-40f6c8e6697b"
+    }
+
+    run get_new_device_identifier \
+            "ubuntu--vg-ubuntu--lv" \
+            "dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv"
+
+    [ $status -eq 0 ]
+    [ "$output" = "dm-name-ubuntu--vg-ubuntu--lv" ]
+}
+
+@test "Get dm-uuid-<dm_uuid> when there is no dm-name-<dm_name>" {
+    function UdevSymlinkName() {
+        echo -n "/dev/ubuntu-vg/ubuntu-lv "
+        echo -n "/dev/disk/by-dname/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/mapper/ubuntu--vg-ubuntu--lv "
+        echo -n "/dev/disk/by-id/dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv "
+        echo -n "/dev/disk/by-uuid/9d830822-b26a-4188-a9e4-40f6c8e6697b"
+    }
+
+    run get_new_device_identifier \
+            "ubuntu--vg-ubuntu--lv" \
+            "dm-name-ubuntu--vg-ubuntu--lv"
+
+    [ $status -eq 0 ]
+    [ "$output" = "dm-uuid-LVM-kmigtK0rFZKTG3R0ZSU7BoydFvlGyVyoy1gIcnddXb4Hl25dUk6elOgEQEkvCgiv" ]
+}

--- a/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
@@ -48,19 +48,7 @@ while read ID DEV_NAME; do
         # we delete DEV_NAME to make sure it won't get used
         DEV_NAME=""
     else
-        # get symlinks defined by udev from a device
-        # UdevSymlinkName() defined in lib/layout-function.sh
-        SYMLINKS=$(UdevSymlinkName $DEV_NAME)
-        set -- $SYMLINKS
-        while [ $# -gt 0 ]; do
-            if [[ $1 =~ /dev/disk/by-id ]]; then
-                # bingo, we found what we are looking for
-                ID_NEW=${1#/dev/disk/by-id/} # cciss-3600508b1001cd2b56e1aeab1f82dd70d
-                break
-            else
-                shift
-            fi
-        done
+        ID_NEW=$(get_new_device_identifier "$DEV_NAME" "$ID")
     fi
     echo $ID $DEV_NAME $ID_NEW
 done < "$OLD_ID_FILE" > "$NEW_ID_FILE"

--- a/usr/share/rear/lib/udev-functions.sh
+++ b/usr/share/rear/lib/udev-functions.sh
@@ -1,0 +1,47 @@
+# Return 0 if source and target device identifiers are of the same type:
+# either both dm-uuid-<dm_name> or both dm-name-<dm_name>, return 1 othwerwise.
+# Return 0 for non device-mapper identifiers.
+# $1: source device identifier
+# $2: target device identifier
+function check_device_identifier_type_match() {
+    local src_id="$1"
+    local dst_id="$2"
+
+    if [[ $src_id =~ ^(dm-uuid-|dm-name-) ]]; then
+        local type="${BASH_REMATCH[1]}"
+        [[ $dst_id =~ ^$type ]]
+        return $?
+    fi
+
+    return 0
+}
+
+# Get actual device identifier
+# $1: source device name
+# $2: source device identifier
+function get_new_device_identifier() {
+    local dev_name="$1"
+    local id="$2"
+    local new_id=""
+
+    local symlinks=""
+    symlinks=$(UdevSymlinkName "$dev_name")
+    # shellcheck disable=SC2086
+    set -- $symlinks
+    while [ $# -gt 0 ]; do
+        if [[ $1 =~ /dev/disk/by-id ]]; then
+            # bingo, we found what we are looking for
+            new_id=${1#/dev/disk/by-id/} # cciss-3600508b1001cd2b56e1aeab1f82dd70d
+
+            # Respect device identifier type to avoid replacing dm-uuid-<dm_uuid>
+            # with dm-name-<dm_name>, and vice versa.
+            if check_device_identifier_type_match "$id" "$new_id"; then
+                echo "$new_id"
+                return 0
+            fi
+        fi
+        shift
+    done
+
+    echo "$new_id"
+}


### PR DESCRIPTION
Respect device identifier type (`dm-name-<dm_name>` / `dm-uuid-<dm_uuid>`) during disk-by-id migration

