### PR TITLE
BCF-7177: Cove Rescue Media 1.4.0 is not compatible with BM 26.6 due to new XFS features

### DIFF
--- a/usr/share/rear/init/COVE/default/010_set_cove_rescue_vars.sh
+++ b/usr/share/rear/init/COVE/default/010_set_cove_rescue_vars.sh
@@ -1,0 +1,16 @@
+# 010_set_cove_rescue_vars.sh
+#
+# Set Cove Rescue Media specific variables when running inside the rescue system.
+
+is_true "$RECOVERY_MODE" || return 0
+
+function get_os_release_field() {
+    local field="$1"
+    grep "^$field=" /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"'
+}
+
+# Pre-1.5.0 Cove Rescue Media versions have the base Debian os-release (ID=debian) where
+# VERSION_ID is the Debian release (e.g. "12"). In that case COVE_RESCUE_MEDIA_VERSION should stay empty.
+if [ "$( get_os_release_field ID )" = "cove" ]; then
+    COVE_RESCUE_MEDIA_VERSION="$( get_os_release_field VERSION_ID )"
+fi

--- a/usr/share/rear/init/COVE/default/010_set_cove_rescue_vars.sh
+++ b/usr/share/rear/init/COVE/default/010_set_cove_rescue_vars.sh
@@ -13,4 +13,5 @@ function get_os_release_field() {
 # VERSION_ID is the Debian release (e.g. "12"). In that case COVE_RESCUE_MEDIA_VERSION should stay empty.
 if [ "$( get_os_release_field ID )" = "cove" ]; then
     COVE_RESCUE_MEDIA_VERSION="$( get_os_release_field VERSION_ID )"
+    COVE_RESCUE_MEDIA_VARIANT="$( get_os_release_field VARIANT_ID )"
 fi

--- a/usr/share/rear/lib/cove-functions.sh
+++ b/usr/share/rear/lib/cove-functions.sh
@@ -103,3 +103,11 @@ function is_cove_rescue_device() {
 
     [ "$label" = "COVE_RESCUE" ]
 }
+
+function is_cove_rescue_media_version_ge() {
+    local required_version="$1"
+    [ -n "$COVE_RESCUE_MEDIA_VERSION" ] || return 1
+    local lower_version
+    lower_version="$(printf '%s\n%s' "$required_version" "$COVE_RESCUE_MEDIA_VERSION" | sort -V | head -n 1)"
+    [ "$lower_version" = "$required_version" ]
+}

--- a/usr/share/rear/lib/cove-functions.sh
+++ b/usr/share/rear/lib/cove-functions.sh
@@ -49,9 +49,18 @@ function is_cove() {
 }
 
 function is_cove_in_azure() {
-    is_cove && grep -qw "cove_azure" /proc/cmdline && \
-        curl -H "Metadata: true" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" \
-            --connect-timeout 3 1>/dev/null 2>&1
+    is_cove || return 1
+    # Older Cove Rescue Media (< 1.5.0) has the base Debian os-release which does not provide our VARIANT,
+    # so fall back to the 'cove_azure' kernel cmdline marker.
+    # TODO: Once we no longer support Cove Rescue Media < 1.5.0, rely unconditionally on
+    # COVE_RESCUE_MEDIA_VARIANT and remove the /proc/cmdline fallback.
+    if [ -n "$COVE_RESCUE_MEDIA_VARIANT" ]; then
+        [ "$COVE_RESCUE_MEDIA_VARIANT" = "azure" ] || return 1
+    else
+        grep -qw "cove_azure" /proc/cmdline || return 1
+    fi
+    curl -H "Metadata: true" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" \
+        --connect-timeout 3 1>/dev/null 2>&1
 }
 
 # Since there is no reliable way of detecting whether it is running in a container or not,

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -203,15 +203,18 @@ function xfs_parse
     xfs_param_opt[24]="-i"
     xfs_param_name[24]="nrext64"
 
-    xfs_param_iname[25]="parent"
-    xfs_param_search[25]="naming_section"
-    xfs_param_opt[25]="-n"
-    xfs_param_name[25]="parent"
+    if ! is_cove || is_cove_rescue_media_version_ge "1.5.0"; then
+        # pre-1.5.0 Cove Rescue Media versions can't handle these mkfs.xfs options
+        xfs_param_iname[25]="parent"
+        xfs_param_search[25]="naming_section"
+        xfs_param_opt[25]="-n"
+        xfs_param_name[25]="parent"
 
-    xfs_param_iname[26]="exchange"
-    xfs_param_search[26]="metadata_section"
-    xfs_param_opt[26]="-i"
-    xfs_param_name[26]="exchange"
+        xfs_param_iname[26]="exchange"
+        xfs_param_search[26]="metadata_section"
+        xfs_param_opt[26]="-i"
+        xfs_param_name[26]="exchange"
+    fi
 
     # Here we will save some variables, that will be later used for
     # calculations (block_size) or due dependencies with other options (crc).
@@ -290,7 +293,8 @@ function xfs_parse
             xfs_opts+="${xfs_param_opt[$i]} $var=$val "
         elif [ "$BACKUP" = "COVE" ]; then
             # Disable unknown features for source xfs_info in Cove Rescue Media
-            local xfs_features=("rmapbt" "reflink" "bigtime" "inobtcount" "nrext64" "parent" "exchange")
+            local xfs_features=("rmapbt" "reflink" "bigtime" "inobtcount" "nrext64")
+            is_cove_rescue_media_version_ge "1.5.0" && xfs_features+=("parent" "exchange")
             if IsInArray "${xfs_param_name[$i]}" "${xfs_features[@]}"; then
                 xfs_opts+="${xfs_param_opt[$i]} ${xfs_param_name[$i]}=0 "
             fi


### PR DESCRIPTION
* add parsing of cove-specific variables from `/etc/os-release` file to get CRM version
* parse `exchange` and `parent` xfs features only if version is >= 1.5.0
* use `VARIANT_ID` option from `/etc/os-release` to check if we're running in azure

[BCF-7177](https://n-able.atlassian.net/browse/BCF-7177)


[BCF-7177]: https://n-able.atlassian.net/browse/BCF-7177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ